### PR TITLE
Add event manager to DI container

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -127,6 +127,7 @@ final class Bootstrap {
 				Configuration\WordPressConfiguration::class,
 				Configuration\HTTPBinAPIClientConfiguration::class,
 				Configuration\WooCommerceConfiguration::class,
+				Configuration\EventManagementConfiguration::class,
 			)
 		);
 

--- a/src/Configuration/EventManagementConfiguration.php
+++ b/src/Configuration/EventManagementConfiguration.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WordPress Event (actions/filters) Management related configuration for the dependency container.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Configuration;
+
+use martinsluters\WooStoreBinaryBinWidget\EventManagement\EventManager;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\DependencyContainer;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\ContainerConfigurationInterface;
+use martinsluters\WooStoreBinaryBinWidget\Subscribers;
+
+/**
+ * WordPress Event (actions/filters) Management related configuration for the dependency container.
+ */
+class EventManagementConfiguration implements ContainerConfigurationInterface {
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @param DependencyContainer $container The container to modify.
+	 */
+	public function modify( DependencyContainer $container ) {
+
+		$container['event_manager'] = $container->service(
+			function ( DependencyContainer $container ) {
+				return new EventManager();
+			}
+		);
+
+		// Add all subscribers to events.
+		$container['subscribers'] = $container->service(
+			function ( DependencyContainer $container ) {
+				$subscribers = array();
+
+				return $subscribers;
+			}
+		);
+	}
+
+}


### PR DESCRIPTION
### Purpose
This PR adds the core event manager the plugins DI container. We will required to subscribe to various events while building the rest of the plugin.