### PR TITLE
Add tab "Binaries Bin" tab to WooCommerce My Account

### DIFF
--- a/resources/templates/woocommerce/binaries-bin-content-list.php
+++ b/resources/templates/woocommerce/binaries-bin-content-list.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Binaries Bin Content List.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! empty( $binaries_bin ) && ! is_wp_error( $binaries_bin ) ) :
+	?>
+	<ul>
+	<?php
+	foreach ( $binaries_bin as $binary_key => $binary_value ) :
+		?>
+		<li>
+			<pre><?php echo esc_html( $binary_key ); ?> : <?php echo esc_html( $binary_value ); ?></pre>
+		</li>
+		<?php
+	endforeach;
+	?>
+	</ul>
+	<?php
+else :
+	?>
+	<p><?php echo esc_html__( 'Your Binary Bin is empty.', 'woo-store-binary-bin-widget' ); ?></p>
+	<?php
+endif;
+
+

--- a/resources/templates/woocommerce/myaccount/binaries-bin-content.php
+++ b/resources/templates/woocommerce/myaccount/binaries-bin-content.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Binaries Bin Content Wrapper.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<section class="woocommerce-binaries-bin-content">
+
+		<h2 class="woocommerce-binaries-bin__title"><?php esc_html_e( 'Binaries Bin Content', 'woo-store-binary-bin-widget' ); ?></h2>
+
+		<?php do_action( 'woostore_binaries_bin_myaccount_content' ); ?>
+</section>

--- a/resources/templates/woocommerce/myaccount/form-binaries-bin.php
+++ b/resources/templates/woocommerce/myaccount/form-binaries-bin.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Binaries Bin Settings Form.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+do_action( 'woostore_binaries_bin_form' ); ?>
+
+<form class="woocommerce-BinariesBinForm binary-binaries" action="" method="post" <?php do_action( 'woostore_binaries_bin_form_tag' ); ?> >
+
+	<?php do_action( 'woostore_binaries_bin_form_start' ); ?>
+
+	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+		<label for="binaries_bin_settings"><?php esc_html_e( 'Binaries Bin Settings', 'woo-store-binary-bin-widget' ); ?>&nbsp;<span class="required">*</span></label>
+		<textarea class="woocommerce-Input woocommerce-Input--textarea input-textarea" name="binaries_bin_settings" id="binaries_bin_settings" rows="2" cols="5" placeholder="<?php esc_attr_e( 'JohnDoe', 'woo-store-binary-bin-widget' ); ?>"><?php echo esc_textarea( $page->get_customer_binary_bin_settings_for_textarea() ); ?></textarea>
+	</p>
+	<div class="clear"></div>
+
+	<?php do_action( 'woostore_binaries_bin_form' ); ?>
+
+	<p>
+		<?php wp_nonce_field( 'save_binaries_bin_settings', 'save-binaries-bin-settings-nonce' ); ?>
+		<button type="submit" class="woocommerce-Button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="save_binaries_bin_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+		<input type="hidden" name="action" value="save_binaries_bin_settings" />
+	</p>
+
+	<?php do_action( 'woostore_binaries_bin_form_end' ); ?>
+</form>
+
+<?php do_action( 'woostore_after_binaries_bin_form' ); ?>

--- a/resources/templates/woocommerce/myaccount/tab-binaries-bin.php
+++ b/resources/templates/woocommerce/myaccount/tab-binaries-bin.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Binaries Bin Tab content.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<div>
+	<?php
+		/**
+		 * Binaries Bin Tab content.
+		 */
+		do_action( 'woostore_binaries_bin_tab_content' );
+	?>
+</div>

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -128,9 +128,15 @@ final class Bootstrap {
 				Configuration\HTTPBinAPIClientConfiguration::class,
 				Configuration\WooCommerceConfiguration::class,
 				Configuration\BinariesBinRepositoryConfiguration::class,
+				Configuration\MyAccountTabConfiguration::class,
 				Configuration\EventManagementConfiguration::class,
 			)
 		);
+
+		// Add WP event subscribers to event manager.
+		foreach ( $this->container['subscribers'] as $subscriber ) {
+			$this->container['event_manager']->add_subscriber( $subscriber );
+		}
 
 		$this->loaded = true;
 	}

--- a/src/Configuration/EventManagementConfiguration.php
+++ b/src/Configuration/EventManagementConfiguration.php
@@ -35,7 +35,9 @@ class EventManagementConfiguration implements ContainerConfigurationInterface {
 		// Add all subscribers to events.
 		$container['subscribers'] = $container->service(
 			function ( DependencyContainer $container ) {
-				$subscribers = array();
+				$subscribers = array(
+					new Subscribers\BinariesBinMyAccountTabSubscriber( $container['my-account:binaries-bin-tab'], $container['woocommerce.current_customer'] ),
+				);
 
 				return $subscribers;
 			}

--- a/src/Configuration/MyAccountTabConfiguration.php
+++ b/src/Configuration/MyAccountTabConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * My Account > Tabs related configuration for the dependency container.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Configuration;
+
+use martinsluters\WooStoreBinaryBinWidget\MyAccount\BinariesBinTab;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\DependencyContainer;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\ContainerConfigurationInterface;
+
+/**
+ * My Account > Tabs related configuration for the dependency container.
+ */
+class MyAccountTabConfiguration implements ContainerConfigurationInterface {
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @param DependencyContainer $container The container to modify.
+	 */
+	public function modify( DependencyContainer $container ) {
+		$container['my-account:binaries-bin-tab'] = $container->service(
+			function ( DependencyContainer $container ) {
+				return new BinariesBinTab( $container['plugin_path'] . 'resources/templates/', $container['woocommerce.current_customer'], $container['binaries_bin_repository'] );
+			}
+		);
+	}
+}

--- a/src/MyAccount/AbstractTab.php
+++ b/src/MyAccount/AbstractTab.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Abstract WooCommerce My Account tab.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\MyAccount;
+
+/**
+ * Abstract WooCommerce My Account tab class.
+ */
+abstract class AbstractTab {
+
+	/**
+	 * Path to the WooCommerce My Account tab templates.
+	 *
+	 * @var string
+	 */
+	protected string $template_path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $template_path The template path.
+	 */
+	public function __construct( string $template_path ) {
+		$this->template_path = $template_path;
+	}
+
+	/**
+	 * Get the tab slug.
+	 *
+	 * @return void
+	 */
+	public function render_content(): void {
+		wc_get_template( 'tab-' . $this->myaccount_tab_slug() . '.php', array( 'page' => $this ), '', $this->template_path . 'woocommerce/myaccount/' );
+	}
+
+	/**
+	 * Get the tab slug.
+	 *
+	 * @return string
+	 */
+	abstract public function myaccount_tab_slug(): string;
+
+	/**
+	 * Get the tab title.
+	 *
+	 * @return string
+	 */
+	abstract public function myaccount_tab_title(): string;
+}

--- a/src/MyAccount/BinariesBinTab.php
+++ b/src/MyAccount/BinariesBinTab.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * WooCommerce My Account Binaries Bin tab.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\MyAccount;
+
+use \WC_Customer;
+use martinsluters\WooStoreBinaryBinWidget\BinariesBinRepository;
+
+/**
+ * WooCommerce My Account Binaries Bin tab class.
+ */
+class BinariesBinTab extends AbstractTab {
+
+	/**
+	 * The current WooCommerce customer.
+	 *
+	 * @var WC_Customer
+	 */
+	protected WC_Customer $current_customer;
+
+	/**
+	 * The binaries bin repository.
+	 *
+	 * @var BinariesBinRepository
+	 */
+	protected BinariesBinRepository $binaries_bin_repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string                $template_path The template path.
+	 * @param WC_Customer           $current_customer The current WooCommerce customer.
+	 * @param BinariesBinRepository $binaries_bin_repository The binaries bin repository.
+	 */
+	public function __construct( string $template_path, WC_Customer $current_customer, BinariesBinRepository $binaries_bin_repository ) {
+		parent::__construct( $template_path );
+		$this->current_customer        = $current_customer;
+		$this->binaries_bin_repository = $binaries_bin_repository;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function myaccount_tab_slug(): string {
+		return 'binaries-bin';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function myaccount_tab_title(): string {
+		return esc_html__( 'Binaries Bin', 'woo-store-binary-bin-widget' );
+	}
+
+	/**
+	 * Render settings form.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_settings_form_section() {
+		wc_get_template( 'form-binaries-bin.php', array( 'page' => $this ), '', $this->template_path . 'woocommerce/myaccount/' );
+	}
+
+	/**
+	 * Render binaries bin content wrapper.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_repository_content_section() {
+		wc_get_template( 'binaries-bin-content.php', array(), '', $this->template_path . 'woocommerce/myaccount/' );
+	}
+
+	/**
+	 * Render binaries bin content list.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_content_list_section() {
+		$binaries_bin = $this->binaries_bin_repository->get_binaries();
+
+		if ( is_wp_error( $binaries_bin ) ) {
+			// translators: %s: HTTP transport service error message.
+			echo esc_html( wp_sprintf( __( 'Error fetching binaries bin from http://httpbin.org/: %s', 'woo-store-binary-bin-widget' ), $binaries_bin->get_error_message() ) );
+			return;
+		}
+
+		wc_get_template( 'binaries-bin-content-list.php', array( 'binaries_bin' => $binaries_bin ), '', $this->template_path . 'woocommerce/' );
+	}
+
+	/**
+	 * Handle binaries bin settings form submission.
+	 *
+	 * @return void
+	 */
+	public function save_binaries_bin_settings() {
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$nonce_value = wc_get_var( $_REQUEST['save-binaries-bin-settings-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) );
+
+		if ( ! wp_verify_nonce( $nonce_value, 'save_binaries_bin_settings' ) ) {
+			return;
+		}
+
+		if ( empty( $_POST['action'] ) || 'save_binaries_bin_settings' !== $_POST['action'] ) {
+			return;
+		}
+
+		wc_nocache_headers();
+
+		// Flush previous notices.
+		wc_clear_notices();
+
+		// Do we have a user/customer at all? Bail quickly if not.
+		if ( $this->current_customer->get_id() <= 0 ) {
+			return;
+		}
+
+		$binaries_bin_settings = ! empty( $_POST['binaries_bin_settings'] ) ? sanitize_textarea_field( wp_unslash( $_POST['binaries_bin_settings'] ) ) : '';
+
+		// Split by line.
+		// "explode" might not work always.
+		$binaries_bin_settings_array = preg_split( "/\r\n|\n|\r/", $binaries_bin_settings );
+
+		// Remove empty ones.
+		$binaries_bin_settings_array = array_filter(
+			$binaries_bin_settings_array,
+			function ( $single_setting_line ) {
+				return ! empty( $single_setting_line );
+			}
+		);
+
+		// Remove non-alphanumeric ones.
+		$did_have_non_alphanumeric   = null;
+		$binaries_bin_settings_array = array_filter(
+			$binaries_bin_settings_array,
+			function ( $single_setting_line ) use ( &$did_have_non_alphanumeric ) {
+				$is_alphanumeric = 1 === preg_match( '/^[a-zA-Z0-9]+$/', $single_setting_line );
+				if ( is_null( $did_have_non_alphanumeric ) || false === $did_have_non_alphanumeric ) {
+					// Flag that there was a non-alphanumeric character to display notice.
+					$did_have_non_alphanumeric = ! $is_alphanumeric;
+				}
+				return $is_alphanumeric;
+			}
+		);
+
+		// Display notice if non-alphanumeric characters were removed.
+		if ( true === $did_have_non_alphanumeric ) {
+			wc_add_notice( __( 'The Binaries Bin settings contained non-alphanumeric characters. These have been removed.', 'woo-store-binary-bin-widget' ), 'error' );
+		}
+
+		// Save value in customers meta data.
+		$this->save_customer_binaries_bin_settings( $binaries_bin_settings_array );
+
+		// Pre-fetch binaries / background cache, to make sure items are available already.
+		// Also resets the cache.
+		$this->binaries_bin_repository->get_binaries( true );
+
+		wc_add_notice( __( 'Binary bin settings changed successfully.', 'woo-store-binary-bin-widget' ) );
+
+		wp_safe_redirect( wc_get_endpoint_url( $this->myaccount_tab_slug(), '', wc_get_page_permalink( 'myaccount' ) ) );
+		exit;
+	}
+
+	/**
+	 * Get customer binaries bin settings to be outputted in textarea.
+	 *
+	 * @return string
+	 */
+	public function get_customer_binary_bin_settings_for_textarea() {
+		$settings = $this->current_customer->get_meta( 'binaries_bin_settings', true );
+
+		if ( is_string( $settings ) ) {
+			return $settings;
+		}
+
+		if ( ! is_array( $settings ) ) {
+			return '';
+		}
+
+		return implode( PHP_EOL, $settings );
+	}
+
+	/**
+	 * Save customer binaries bin settings.
+	 *
+	 * @param array $settings Settings to save.
+	 * @return void
+	 */
+	protected function save_customer_binaries_bin_settings( $settings ) {
+		$this->current_customer->update_meta_data( 'binaries_bin_settings', $settings );
+		$this->current_customer->save_meta_data();
+	}
+}

--- a/src/Subscribers/BinariesBinMyAccountTabSubscriber.php
+++ b/src/Subscribers/BinariesBinMyAccountTabSubscriber.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * WooCommerce My Account Binaries Bin Tab subscriber.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Subscribers;
+
+use martinsluters\WooStoreBinaryBinWidget\MyAccount\AbstractTab;
+use martinsluters\WooStoreBinaryBinWidget\EventManagement\EventSubscriberInterface;
+
+/**
+ * WooCommerce My Account Binaries Bin Tab subscriber class.
+ */
+class BinariesBinMyAccountTabSubscriber implements EventSubscriberInterface {
+
+	/**
+	 * The my account tab to register.
+	 *
+	 * @var AbstractTab
+	 */
+	protected $tab;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AbstractTab $tab The new my account tab to register.
+	 */
+	public function __construct( AbstractTab $tab ) {
+		$this->tab = $tab;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_subscribed_events(): array {
+		return array(
+			'init'                                      => 'register_binaries_bin_endpoint',
+			'query_vars'                                => 'add_binary_bin_query_var',
+			'woocommerce_account_menu_items'            => 'add_binaries_bin_tab',
+			'woocommerce_account_binaries-bin_endpoint' => 'render_tab_content',
+			'woostore_binaries_bin_tab_content'         => 'render_binaries_bin_tab_content',
+			'woostore_binaries_bin_myaccount_content'   => 'render_binaries_bin_content_list_section',
+			'template_redirect'                         => 'save_binaries_bin_settings',
+		);
+	}
+
+	/**
+	 * Render the binaries bin tab content.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_tab_content() {
+		$this->render_binaries_bin_tab_form();
+		$this->render_binaries_bin_tab_repository_content();
+	}
+
+	/**
+	 * Render the binaries bin tab wrapper.
+	 *
+	 * @return void
+	 */
+	public function render_tab_content() {
+		$this->tab->render_content();
+	}
+
+	/**
+	 * Render the binaries bin tab settings form.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_tab_form() {
+		$this->tab->render_binaries_bin_settings_form_section();
+	}
+
+	/**
+	 * Add the binaries bin rewrite API endpoint.
+	 *
+	 * @return void
+	 */
+	public function register_binaries_bin_endpoint() {
+		add_rewrite_endpoint( $this->tab->myaccount_tab_slug(), EP_ROOT | EP_PAGES );
+	}
+
+	/**
+	 * Add the binaries bin WP query var.
+	 *
+	 * @param array $vars The query vars.
+	 * @return array
+	 */
+	public function add_binary_bin_query_var( $vars ) {
+		$vars[] = $this->tab->myaccount_tab_slug();
+		return $vars;
+	}
+
+	/**
+	 * Add the binaries bin tab to the my account tabs menu.
+	 *
+	 * @param array $items The existing my account tabs.
+	 * @return array
+	 */
+	public function add_binaries_bin_tab( $items ) {
+		$items[ $this->tab->myaccount_tab_slug() ] = esc_html( $this->tab->myaccount_tab_title() );
+		return $items;
+	}
+
+	/**
+	 * Handle the binaries bin settings form's submission.
+	 *
+	 * @return void
+	 */
+	public function save_binaries_bin_settings() {
+		$this->tab->save_binaries_bin_settings();
+	}
+
+	/**
+	 * Render the binaries bin content list.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_content_list_section() {
+		$this->tab->render_binaries_bin_content_list_section();
+	}
+
+	/**
+	 * Render the binaries bin repository content.
+	 *
+	 * @return void
+	 */
+	public function render_binaries_bin_tab_repository_content() {
+		$this->tab->render_binaries_bin_repository_content_section();
+	}
+}


### PR DESCRIPTION
# Purpose 
We requested to implement functionality to fetch a list of elements from HTTPBin (httpbin.org) API, filtering from the currently logged in user preferences. 

A currently logged in user should be able to enter an alphanumeric list of elements as user preferences in a basic UI under My Account "Binaries Bin" tab, which should be then passed on as an array to the HTTPBin API POST request calls.

The information fetched for each user should be displayed under on the same tab under user preferences form.

The solution as a whole needs to be as secure as possible.

This PR add the new My Account "Binaries Bin" tab and completes the requirements.

### Steps to manually test this PR:
> Note: Domain, port and schema http://localhost:8087 in the below steps should be changed to actual environment data.

1. Checkout this PR
2. Log into the WordPress installation via http://localhost:8087/wp-admin
3. Make sure WooCommerce and WooStore Binary Bin Widget plugins are active http://localhost:8087/wp-admin/plugins.php
4. Flush permalinks by going to http://localhost:8087/wp-admin/options-permalink.php or via WP-CLI 
5. View tab http://localhost:8087/my-account/binaries-bin/

### Screenshot of the new tab

![CleanShot 2023-05-03 at 22 50 34@2x](https://user-images.githubusercontent.com/18058037/236031588-069926c6-5ce1-48f1-9750-2673ba4faaae.png)
