### PR TITLE
Create Binaries Bin WordPress widget

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -129,6 +129,7 @@ final class Bootstrap {
 				Configuration\WooCommerceConfiguration::class,
 				Configuration\BinariesBinRepositoryConfiguration::class,
 				Configuration\MyAccountTabConfiguration::class,
+				Configuration\WidgetConfiguration::class,
 				Configuration\EventManagementConfiguration::class,
 			)
 		);

--- a/src/Configuration/EventManagementConfiguration.php
+++ b/src/Configuration/EventManagementConfiguration.php
@@ -37,6 +37,7 @@ class EventManagementConfiguration implements ContainerConfigurationInterface {
 			function ( DependencyContainer $container ) {
 				$subscribers = array(
 					new Subscribers\BinariesBinMyAccountTabSubscriber( $container['my-account:binaries-bin-tab'], $container['woocommerce.current_customer'] ),
+					new Subscribers\WidgetSubscriber( $container['widgets.binary_bin'] ),
 				);
 
 				return $subscribers;

--- a/src/Configuration/WidgetConfiguration.php
+++ b/src/Configuration/WidgetConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Widgets related configuration for the dependency container.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Configuration;
+
+use martinsluters\WooStoreBinaryBinWidget\Widget;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\DependencyContainer;
+use martinsluters\WooStoreBinaryBinWidget\DependencyInjection\ContainerConfigurationInterface;
+
+/**
+ * Widgets related configuration for the dependency container.
+ */
+class WidgetConfiguration implements ContainerConfigurationInterface {
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * @param DependencyContainer $container The container to modify.
+	 */
+	public function modify( DependencyContainer $container ) {
+		$container['widgets.binary_bin'] = $container->service(
+			function ( DependencyContainer $container ) {
+				return new Widget\BinaryBinWidget( $container['binaries_bin_repository'], $container['woocommerce.current_customer'], $container['plugin_path'] . 'resources/templates/' );
+			}
+		);
+	}
+}

--- a/src/Subscribers/WidgetSubscriber.php
+++ b/src/Subscribers/WidgetSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Widgets event subscriber.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Subscribers;
+
+use \WP_Widget;
+use martinsluters\WooStoreBinaryBinWidget\EventManagement\EventSubscriberInterface;
+
+/**
+ * Widgets event subscriber class.
+ */
+class WidgetSubscriber implements EventSubscriberInterface {
+
+	/**
+	 * The widget.
+	 *
+	 * @var WP_Widget
+	 */
+	protected $widget;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_Widget $widget The WP widget to subscribe.
+	 */
+	public function __construct( WP_Widget $widget ) {
+		$this->widget = $widget;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_subscribed_events(): array {
+		return array(
+			'widgets_init' => 'register_widget',
+		);
+	}
+
+	/**
+	 * Register the widget.
+	 *
+	 * @return void
+	 */
+	public function register_widget() {
+		register_widget( $this->widget );
+	}
+}

--- a/src/Widget/BinaryBinWidget.php
+++ b/src/Widget/BinaryBinWidget.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Binary Bin Widget.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Widget;
+
+use \WP_Widget;
+use \WC_Customer;
+use martinsluters\WooStoreBinaryBinWidget\BinariesBinRepository;
+
+/**
+ * Binary Bin Widget.
+ */
+class BinaryBinWidget extends WP_Widget {
+
+	/**
+	 * The binaries bin repository.
+	 *
+	 * @var BinariesBinRepository
+	 */
+	protected BinariesBinRepository $binaries_bin_repository;
+
+	/**
+	 * The current customer.
+	 *
+	 * @var WC_Customer
+	 */
+	protected WC_Customer $current_customer;
+
+	/**
+	 * Path to the templates.
+	 *
+	 * @var string
+	 */
+	protected string $template_path;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param BinariesBinRepository $binaries_bin_repository The binaries bin repository.
+	 * @param WC_Customer           $current_customer The current WordPress customer.
+	 * @param string                $template_path The path to the templates.
+	 */
+	public function __construct( BinariesBinRepository $binaries_bin_repository, WC_Customer $current_customer, string $template_path ) {
+		$this->binaries_bin_repository = $binaries_bin_repository;
+		$this->current_customer        = $current_customer;
+		$this->template_path           = $template_path;
+		parent::__construct(
+			'woo-store-binary-bin-widget',
+			'Woo Store Binary Bin Widget',
+			array(
+				'description' => 'Woo Store Binary Bin Widget',
+			)
+		);
+	}
+
+	/**
+	 * Render the widget.
+	 *
+	 * @param array $args The widget arguments.
+	 * @param array $instance The widget instance.
+	 */
+	public function widget( $args, $instance ) {
+		echo '<div class="widget widget_woo_store_binary_bin_widget">';
+		echo '<h2 class="widget-title">' . esc_html__( 'Binary Bin Contents > Widget', 'woo-store-binary-bin-widget' ) . '</h2>';
+		echo '<div class="widget-content">';
+		$this->get_content();
+		echo '</div>';
+		echo '</div>';
+	}
+
+	/**
+	 * Outputs the widget contents.
+	 *
+	 * @return void.
+	 */
+	protected function get_content(): void {
+		if ( 0 >= $this->current_customer->get_id() ) {
+			echo '<p>' . esc_html__( 'Please log in to see your Binary Bin contents.', 'woo-store-binary-bin-widget' ) . '</p>';
+			return;
+		}
+
+		$binaries_bin = $this->binaries_bin_repository->get_binaries();
+
+		wc_get_template( 'binaries-bin-content-list.php', array( 'binaries_bin' => $binaries_bin ), '', $this->template_path . 'woocommerce/' );
+	}
+}


### PR DESCRIPTION
# Purpose 
We requested to implement functionality to fetch a list of elements from HTTPBin (httpbin.org) API, filtering from the currently logged in user preferences.

The fetched information should be displayed for each user in a widget.

The solution as a whole needs to be as secure as possible and should impact performance as little as possible.

This PR creates and registers a new widget "**Woo Store Binary Bin Widget**".


### Steps to manually test this PR:

Note: Domain, port and schema http://localhost:8087/ in the below steps should be changed to actual environment data.

1. Checkout this PR
2. Log into the WordPress installation via http://localhost:8087/wp-admin
3. Make sure WooCommerce and WooStore Binary Bin Widget plugins are active http://localhost:8087/wp-admin/plugins.php
4. Flush permalinks by going to http://localhost:8087/wp-admin/options-permalink.php or via WP-CLI 
5. Add the new "Woo Store Binary Bin Widget" widget on one of the footer widget areas.
6. View tab http://localhost:8087/my-account/binaries-bin/
7. Observe widget in footer

Screenshot of the new widget
![CleanShot 2023-05-03 at 23 08 27@2x](https://user-images.githubusercontent.com/18058037/236037063-74ad96e7-2882-432c-9039-cbb5c195250a.png)



