### PR TITLE
Flush rewrite rules on the plugin activation event to automatically allow to visit My Account's Binaries Bin tab

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -60,10 +60,11 @@ final class Bootstrap {
 		// Load the plugin's dependency injection container with some initial dependencies.
 		$this->container = new DependencyContainer(
 			array(
-				'main_plugin_file' => $main_plugin_file,
-				'plugin_path'      => plugin_dir_path( $main_plugin_file ),
-				'plugin_version'   => self::VERSION,
-				'plugin_slug'      => self::SLUG,
+				'main_plugin_file'            => $main_plugin_file,
+				'plugin_path'                 => plugin_dir_path( $main_plugin_file ),
+				'plugin_version'              => self::VERSION,
+				'plugin_slug'                 => self::SLUG,
+				'plugin_activation_flag_slug' => 'activated_' . self::SLUG,
 			)
 		);
 		$this->loaded    = false;
@@ -107,6 +108,8 @@ final class Bootstrap {
 	 */
 	public function init(): void {
 		add_action( 'after_setup_theme', array( $this, 'bootstrap_core' ) );
+
+		register_activation_hook( $this->container['main_plugin_file'], array( $this, 'activate' ) );
 	}
 
 	/**
@@ -140,6 +143,17 @@ final class Bootstrap {
 		}
 
 		$this->loaded = true;
+	}
+
+	/**
+	 * Plugin's activation callback.
+	 * Let's go with the simple options-based activation solution described below.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/register_activation_hook/#process-flow
+	 * @return void
+	 */
+	public function activate() {
+		update_option( $this->container['plugin_activation_flag_slug'], $this->container['plugin_slug'], false );
 	}
 
 	/**

--- a/src/Configuration/EventManagementConfiguration.php
+++ b/src/Configuration/EventManagementConfiguration.php
@@ -38,6 +38,7 @@ class EventManagementConfiguration implements ContainerConfigurationInterface {
 				$subscribers = array(
 					new Subscribers\BinariesBinMyAccountTabSubscriber( $container['my-account:binaries-bin-tab'], $container['woocommerce.current_customer'] ),
 					new Subscribers\WidgetSubscriber( $container['widgets.binary_bin'] ),
+					new Subscribers\PluginActivationSubscriber( $container['plugin_activation_flag_slug'] ),
 				);
 
 				return $subscribers;

--- a/src/Subscribers/PluginActivationSubscriber.php
+++ b/src/Subscribers/PluginActivationSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Plugin activation event subscriber.
+ * Subscribe to WP events on the plugin's activation.
+ *
+ * @package WooStoreBinaryBinWidget
+ */
+
+declare( strict_types=1 );
+
+namespace martinsluters\WooStoreBinaryBinWidget\Subscribers;
+
+use martinsluters\WooStoreBinaryBinWidget\EventManagement\EventSubscriberInterface;
+
+/**
+ * Plugin activation event subscriber.
+ */
+class PluginActivationSubscriber implements EventSubscriberInterface {
+
+	/**
+	 * The plugin activation flag slug.
+	 *
+	 * @var string
+	 */
+	protected string $plugin_activation_flag_slug;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $plugin_activation_flag_slug The plugin activation flag slug.
+	 */
+	public function __construct( string $plugin_activation_flag_slug ) {
+		$this->plugin_activation_flag_slug = $plugin_activation_flag_slug;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_subscribed_events(): array {
+		$activation_flag = get_option( $this->plugin_activation_flag_slug, true );
+
+		if ( false === $activation_flag ) {
+			return array(); // Nothing to subscribe to.
+		}
+
+		/**
+		 * Indicate that the plugin is activated.
+		 *
+		 * @see https://developer.wordpress.org/reference/functions/register_activation_hook/#process-flow
+		 */
+		delete_option( $this->plugin_activation_flag_slug );
+
+		return array(
+			// Flush permalinks after binary bin my account page (tab) is registered.
+			'init' => array( 'flush_permalinks', 50 ),
+		);
+	}
+
+	/**
+	 * Flush permalinks.
+	 *
+	 * @return void
+	 */
+	public function flush_permalinks() {
+		flush_rewrite_rules();
+	}
+}


### PR DESCRIPTION
# Purpose
We are registering a new WooCommerce > My Account tab after plugin activation and it requires changes to rewrite rules.

We want to flush rewrite rules on plugin activation and not manually.

Steps to manually test this PR:

> Note: Domain, port and schema http://localhost:8087/ in the below steps should be changed to actual environment data.

1. Checkout this PR
2. Log into the WordPress installation via http://localhost:8087/wp-admin
3. Make sure `WooCommerce` and `WooStore Binary Bin Widget` plugins are active http://localhost:8087/wp-admin/plugins.php
4. Flush permalinks by going to http://localhost:8087/wp-admin/options-permalink.php or via WP-CLI 
5. Observe that http://localhost:8087/my-account/binaries-bin/ does not give back 404 page.
6. Deactivate `WooStore Binary Bin Widget` plugin.
7.  Flush permalinks by going to http://localhost:8087/wp-admin/options-permalink.php and close the page in browser or  flush via WP-CLI 
8. Observe that http://localhost:8087/my-account/binaries-bin/ gives back 404 page.
9. Activate `WooStore Binary Bin Widget` plugin.
10. Observe that http://localhost:8087/my-account/binaries-bin/ does not give back 404 page. 🥳 