### PR TITLE
Avoid loading core functionality if WooCommerce plugin is inactive

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -107,6 +107,12 @@ final class Bootstrap {
 	 * @return void
 	 */
 	public function init(): void {
+
+		// Check plugin's dependencies/requirements.
+		if ( ! $this->check_plugin_requirements() ) {
+			return;
+		}
+
 		add_action( 'after_setup_theme', array( $this, 'bootstrap_core' ) );
 
 		register_activation_hook( $this->container['main_plugin_file'], array( $this, 'activate' ) );
@@ -154,6 +160,20 @@ final class Bootstrap {
 	 */
 	public function activate() {
 		update_option( $this->container['plugin_activation_flag_slug'], $this->container['plugin_slug'], false );
+	}
+
+	/**
+	 * Check plugin's dependencies.
+	 *
+	 * @return bool
+	 */
+	public function check_plugin_requirements() {
+
+		// Check if WooCommerce is active.
+		if ( ! defined( 'WC_VERSION' ) ) {
+			return false;
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
# Purpose
Our plugin is based on current WooCommerce Customer and it's user preferences set in WooCommerces's My Account thus we can't allow loading the main functionality in case WooCommerce is not activated.

This PR adds a guard statement before loading core functionality.

Steps to manually test this PR:

> Note: Domain, port and schema http://localhost:8087/ in the below steps should be changed to actual environment data.

1. Checkout this PR
2. Log into the WordPress installation via http://localhost:8087/wp-admin
3. Make sure `WooCommerce` and `WooStore Binary Bin Widget` plugins are active http://localhost:8087/wp-admin/plugins.php
4. Add a new "Woo Store Binary Bin Widget" widget on one of the footer widget areas. http://localhost:8087/wp-admin/widgets.php
5. Observe that http://localhost:8087/my-account/binaries-bin/ widget appears on footer.
6. Deactivate `WooCommerce` plugin.
8. Observe that on http://localhost:8087/my-account/binaries-bin/ there is no "Woo Store Binary Bin Widget" widget displayed and no error is thrown.
9. Activate `WooCommerce` plugin.
10. Observe that on http://localhost:8087/my-account/binaries-bin/ the widget "Woo Store Binary Bin Widget" is displayed again. 🥳
